### PR TITLE
Fix for missing generated header file during compile of projects using this plugin

### DIFF
--- a/ios/Classes/FlutterNordicDfuPlugin.m
+++ b/ios/Classes/FlutterNordicDfuPlugin.m
@@ -1,5 +1,12 @@
 #import "FlutterNordicDfuPlugin.h"
+#if __has_include(<flutter_nordic_dfu/flutter_nordic_dfu-Swift.h>)
 #import <flutter_nordic_dfu/flutter_nordic_dfu-Swift.h>
+#else
+// Support project import fallback if the generated compatibility header
+// is not copied when this plugin is created as a library.
+// https://forums.swift.org/t/swift-static-libraries-dont-copy-generated-objective-c-header/19816
+#import "flutter_nordic_dfu-Swift.h"
+#endif
 
 @implementation FlutterNordicDfuPlugin
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {


### PR DESCRIPTION
Newer versions of the Flutter plugin system have a guard around the generated header file. 

Without this change, projects attempting to use the library receive a compile error like the following:

```
    /v3/mobile/flutter-nordic-dfu/ios/Classes/FlutterNordicDfuPlugin.m:2:9: fatal error: 'flutter_nordic_dfu/flutter_nordic_dfu-Swift.h' file not found
    #import <flutter_nordic_dfu/flutter_nordic_dfu-Swift.h>
```

I've added the guard that is now in place on newly generated Flutter plugin projects to prevent this issue.