### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ class ProgressListenerListener extends DfuProgressListenerAdapter {
 
 /// Or you can use DefaultDfuProgressListenerAdapter
 await FlutterNordicDfu.startDfu(
-      '/file/to/zip/path/file.zip',
+      'EB:75:AD:E3:CA:CF',
       'assets/file.zip',
       fileInAsset: true,
       progressListener:


### PR DESCRIPTION
The first argument should be the device-address and not the path to the zip.