### PR TITLE
Add parameters on iOS to fix problems with DFU

### DIFF
--- a/ios/Classes/SwiftFlutterNordicDfuPlugin.swift
+++ b/ios/Classes/SwiftFlutterNordicDfuPlugin.swift
@@ -52,11 +52,20 @@ public class SwiftFlutterNordicDfuPlugin: NSObject, FlutterPlugin, DFUServiceDel
             }
             
             let alternativeAdvertisingNameEnabled = arguments["alternativeAdvertisingNameEnabled"] as? Bool
+
+            let forceScanningForNewAddressInLegacyDfu = (arguments["forceScanningForNewAddressInLegacyDfu"] as? Bool) ?? false
+
+            let numberOfPackets = (arguments["numberOfPackets"] as? UInt16)
+
+            let enablePRNs = (arguments["enablePRNs"] as? Bool) ?? false
             
             startDfu(address,
                      name: name,
                      filePath: filePath,
                      forceDfu: forceDfu,
+                     numberOfPackets: numberOfPackets,
+                     enablePRNs: enablePRNs,
+                     forceScanningForNewAddressInLegacyDfu: forceScanningForNewAddressInLegacyDfu,
                      enableUnsafeExperimentalButtonlessServiceInSecureDfu: enableUnsafeExperimentalButtonlessServiceInSecureDfu,
                      alternativeAdvertisingNameEnabled: alternativeAdvertisingNameEnabled,
                      result: result)
@@ -71,6 +80,9 @@ public class SwiftFlutterNordicDfuPlugin: NSObject, FlutterPlugin, DFUServiceDel
         name: String?,
         filePath: String,
         forceDfu: Bool?,
+        numberOfPackets: UInt16?,
+        enablePRNs: Bool,
+        forceScanningForNewAddressInLegacyDfu: Bool,
         enableUnsafeExperimentalButtonlessServiceInSecureDfu: Bool?,
         alternativeAdvertisingNameEnabled: Bool?,
         result: @escaping FlutterResult) {
@@ -101,6 +113,12 @@ public class SwiftFlutterNordicDfuPlugin: NSObject, FlutterPlugin, DFUServiceDel
         if let alternativeAdvertisingNameEnabled = alternativeAdvertisingNameEnabled {
             dfuInitiator.alternativeAdvertisingNameEnabled = alternativeAdvertisingNameEnabled
         }
+        
+        if let numberOfPackets = numberOfPackets, enablePRNs {
+            dfuInitiator.packetReceiptNotificationParameter = numberOfPackets
+        }
+
+        dfuInitiator.forceScanningForNewAddressInLegacyDfu = forceScanningForNewAddressInLegacyDfu
         
         pendingResult = result
         deviceAddress = address

--- a/lib/flutter_nordic_dfu.dart
+++ b/lib/flutter_nordic_dfu.dart
@@ -169,7 +169,6 @@ class FlutterNordicDfu {
       'restoreBond': androidSpecialParameter?.restoreBond,
       'packetReceiptNotificationsEnabled':
           androidSpecialParameter?.packetReceiptNotificationsEnabled,
-      'restoreBond': androidSpecialParameter?.restoreBond,
       'startAsForegroundService':
           androidSpecialParameter?.startAsForegroundService,
       'alternativeAdvertisingNameEnabled':

--- a/lib/flutter_nordic_dfu.dart
+++ b/lib/flutter_nordic_dfu.dart
@@ -61,8 +61,12 @@ class IosSpecialParameter {
   ///Defaults to true.
   final bool alternativeAdvertisingNameEnabled;
 
+  ///Defaults to false
+  final bool forceScanningForNewAddressInLegacyDfu;
+
   const IosSpecialParameter({
     this.alternativeAdvertisingNameEnabled,
+    this.forceScanningForNewAddressInLegacyDfu = false,
   });
 }
 


### PR DESCRIPTION
This pull request adds the parameters needful to fix the problem described here https://github.com/NordicSemiconductor/IOS-Pods-DFU-Library/issues/368#issuecomment-619066196.

So if you have some kind of troubles with DFU on iOS you can follow the solution explained here https://github.com/NordicSemiconductor/Android-DFU-Library/issues/262#issuecomment-665493850 and then use the parameter `forceScanningForNewAddressInLegacyDfu` in a way like that:
```dart
FlutterNordicDfu.startDfu(
   //other parameters
   iosSpecialParameter: IosSpecialParameter(forceScanningForNewAddressInLegacyDfu: true),
)
```

The changes made are:

- add forceScanningForNewAddressInLegacyDfu in IosSpecialParameter but this should be done in the Android version too
- mapped the parameters `enablePRNs` and `numberOfPackets` on the iOS version because until now they aren't used
- removed a duplicate parameter